### PR TITLE
Update to NodeGit 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "jsdoc-to-markdown": "^1.3.2"
   },
   "peerDependencies": {
-    "nodegit": ">=0.5.0"
   },
   "dependencies": {
     "nodegit-promise": "^4.0.0"
+    "nodegit": ">=0.13.0"
   }
 }

--- a/spec/utils/RepoUtils.js
+++ b/spec/utils/RepoUtils.js
@@ -7,12 +7,11 @@ const RepoUtils = {
   repoDir: '../repos',
 
   addFileToIndex(repository, fileName) {
-    return repository.openIndex()
+    return repository.index()
       .then((index) => {
-        index.read(1);
-        index.addByPath(fileName);
-        index.write();
-        return index.writeTree();
+        return index.addByPath(fileName)
+          .then(() => index.write())
+          .then(() => index.writeTree());
       });
   },
 

--- a/src/utils/RepoUtils.js
+++ b/src/utils/RepoUtils.js
@@ -20,7 +20,7 @@ const RepoUtils = {
         };
         return NodeGit.Merge.merge(repo, fromCommit, null, checkoutOpts);
       })
-      .then(() => repo.openIndex())
+      .then(() => repo.index())
       .then((index) => {
         if (index.hasConflicts && index.hasConflicts()) {
           return Promise.reject(index);


### PR DESCRIPTION
Lots of functions on `Index.prototype` were made async and `Repository#index` was used in lieu of `Repository#openIndex`