### PR TITLE
Remove `nodegit-promise`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
     "jsdoc-to-markdown": "^1.3.2"
   },
   "peerDependencies": {
-  },
-  "dependencies": {
-    "nodegit-promise": "^4.0.0"
     "nodegit": ">=0.13.0"
   }
 }

--- a/spec/tests/Base-spec.js
+++ b/spec/tests/Base-spec.js
@@ -1,7 +1,6 @@
 /* eslint prefer-arrow-callback: 0 */
 
 const NodeGit = require('nodegit');
-const Promise = require('nodegit-promise');
 
 const Base = require('../../src/Base');
 const Config = require('../../src/Config');

--- a/src/Feature.js
+++ b/src/Feature.js
@@ -1,4 +1,3 @@
-const Promise = require('nodegit-promise');
 const NodeGit = require('nodegit');
 const Config = require('./Config');
 

--- a/src/Hotfix.js
+++ b/src/Hotfix.js
@@ -1,4 +1,3 @@
-const Promise = require('nodegit-promise');
 const NodeGit = require('nodegit');
 const Config = require('./Config');
 

--- a/src/Release.js
+++ b/src/Release.js
@@ -1,4 +1,3 @@
-const Promise = require('nodegit-promise');
 const NodeGit = require('nodegit');
 const Config = require('./Config');
 

--- a/src/utils/Promisify.js
+++ b/src/utils/Promisify.js
@@ -1,5 +1,3 @@
-const Promise = require('nodegit-promise');
-
 const promisify = function promisify(fn) {
   return function() {
     let resolve;

--- a/src/utils/RepoUtils.js
+++ b/src/utils/RepoUtils.js
@@ -1,4 +1,3 @@
-const Promise = require('nodegit-promise');
 const NodeGit = require('nodegit');
 
 const MergeUtils = require('./MergeUtils');


### PR DESCRIPTION
NodeGit v0.13.0 doesn't need `nodegit-promise` anymore so we should remove the dependency.