### PR TITLE
Give access to merge messages before they're utilized

### DIFF
--- a/src/Feature.js
+++ b/src/Feature.js
@@ -70,7 +70,7 @@ class Feature {
    * @return {Commit}   The commit created by finishing the feature
    */
   static finishFeature(repo, featureName, options = {}) {
-    const {keepBranch, isRebase} = options;
+    const {keepBranch, isRebase, processMergeMessageCallback} = options;
 
     if (!repo) {
       return Promise.reject(new Error('Repo is required'));
@@ -113,7 +113,7 @@ class Feature {
         cancelDevelopMerge = isSameCommit || isRebase;
 
         if (!cancelDevelopMerge) {
-          return utils.Repo.merge(developBranch, featureBranch, repo);
+          return utils.Repo.merge(developBranch, featureBranch, repo, processMergeMessageCallback);
         } else if (isRebase && !isSameCommit) {
           return utils.Repo.rebase(developBranch, featureBranch, repo);
         }

--- a/src/Hotfix.js
+++ b/src/Hotfix.js
@@ -63,7 +63,7 @@ class Hotfix {
    * @return {Commit}   The commit created by finishing the hotfix
    */
   static finishHotfix(repo, hotfixVersion, options = {}) {
-    const {keepBranch, message} = options;
+    const {keepBranch, message, processMergeMessageCallback} = options;
 
     if (!repo) {
       return Promise.reject(new Error('Repo is required'));
@@ -116,7 +116,7 @@ class Hotfix {
 
         // Merge hotfix into develop
         if (!cancelDevelopMerge) {
-          return utils.Repo.merge(developBranch, hotfixBranch, repo);
+          return utils.Repo.merge(developBranch, hotfixBranch, repo, processMergeMessageCallback);
         }
         return Promise.resolve();
       })
@@ -126,7 +126,7 @@ class Hotfix {
         const tagName = versionPrefix + hotfixVersion;
         // Merge the hotfix branch into master
         if (!cancelMasterMerge) {
-          return utils.Repo.merge(masterBranch, hotfixBranch, repo)
+          return utils.Repo.merge(masterBranch, hotfixBranch, repo, processMergeMessageCallback)
             .then((oid) => utils.Tag.create(oid, tagName, message, repo));
         }
 

--- a/src/Release.js
+++ b/src/Release.js
@@ -70,7 +70,7 @@ class Release {
    * @return {Commit}   The commit created by finishing the release
    */
   static finishRelease(repo, releaseVersion, options = {}) {
-    const {keepBranch, message} = options;
+    const {keepBranch, message, processMergeMessageCallback} = options;
 
     if (!repo) {
       return Promise.reject(new Error('Repo is required'));
@@ -123,7 +123,7 @@ class Release {
 
         // Merge release into develop
         if (!cancelDevelopMerge) {
-          return utils.Repo.merge(developBranch, releaseBranch, repo);
+          return utils.Repo.merge(developBranch, releaseBranch, repo, processMergeMessageCallback);
         }
         return Promise.resolve();
       })
@@ -133,7 +133,7 @@ class Release {
         const tagName = versionPrefix + releaseVersion;
         // Merge the release branch into master
         if (!cancelMasterMerge) {
-          return utils.Repo.merge(masterBranch, releaseBranch, repo)
+          return utils.Repo.merge(masterBranch, releaseBranch, repo, processMergeMessageCallback)
             .then((oid) => utils.Tag.create(oid, tagName, message, repo));
         }
 

--- a/src/utils/MergeUtils.js
+++ b/src/utils/MergeUtils.js
@@ -1,6 +1,20 @@
 const MergeUtils = {
   getMergeMessage(toBranch, fromBranch) {
-    return `Merged ${fromBranch.shorthand()} into ${toBranch.shorthand()}`;
+    let mergeDecorator;
+    if (fromBranch.isTag()) {
+      mergeDecorator = 'tag';
+    } else if (fromBranch.isRemote()) {
+      mergeDecorator = 'remote-tracking branch';
+    } else {
+      mergeDecorator = 'branch';
+    }
+
+    const message = `Merge ${mergeDecorator} '${fromBranch.shorthand()}'`;
+
+    // https://github.com/git/git/blob/master/builtin/fmt-merge-msg.c#L456-L459
+    return toBranch.shorthand() !== 'master'
+      ? `${message} into ${toBranch.shorthand()}`
+      : message;
   }
 };
 


### PR DESCRIPTION
When merging branches, we should provide a callback that allows users to inspect and modify the message that will be used for merging.

The generated merge message itself was also incorrect when compared to git core, and so has been updated to match git core.