### PR TITLE
Do not checkout if we kept branch after rebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodegit-flow",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "nodegit-flow contains gitflow methods that aren't include in the vanilla nodegit package",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/Feature.js
+++ b/src/Feature.js
@@ -131,7 +131,7 @@ class Feature {
       })
       .then((_mergeCommit) => {
         mergeCommit = _mergeCommit;
-        if (cancelDevelopMerge) {
+        if (cancelDevelopMerge && !keepBranch) {
           return repo.checkoutBranch(developBranch);
         }
         return Promise.resolve();


### PR DESCRIPTION
In the scenario that we have the `develop` branch checked out, and we perform a finish feature on `feature/arbitrary`, where `isRebase` is set to true and we have `keepBranch` set to true, after the rebase finishes, develop gets checked out. 

This does not match the way git core rebases and is a bit unexpected behavior.