### PR TITLE
Fire a callback describe merge operations before they occur

### DIFF
--- a/docs/Hotfix.md
+++ b/docs/Hotfix.md
@@ -45,6 +45,7 @@ Finishes a git flow "hotfix"
 | keepBranch | Boolean | Keep the branch after merge |
 | message | String | Tag will be created with this message |
 | processMergeMessageCallback | Function | Callback that is fired before merge occurs. If the callback returns a Promise, the **processMergeMessageCallback** promise must succeed before the merge occurs. The result of the **processMergeMessageCallback** must be a string or a promise that resolves to a string, as that message will be used for the merge message. the **processMergeMessageCallback** will be called with the generated merge message as a parameter. |
+| beforeMergeCallback | Function | Callback fired immediately before a merge occurs. Is parameterized by targetBranchName and hotFixBranchName |
 | postDevelopMergeCallback | Function | Callback fired after a successful merge with development occurs. |
 | postMasterMergeCallback | Function | Callback fired after a successful merge with master occurs. |
 

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -45,6 +45,7 @@ Finishes a git flow "release"
 | keepBranch | Boolean | Keep the branch after merge |
 | message | String | Tag will be created with this message |
 | processMergeMessageCallback | Function | Callback that is fired before merge occurs. If the callback returns a Promise, the **processMergeMessageCallback** promise must succeed before the merge occurs. The result of the **processMergeMessageCallback** must be a string or a promise that resolves to a string, as that message will be used for the merge message. the **processMergeMessageCallback** will be called with the generated merge message as a parameter. |
+| beforeMergeCallback | Function | Callback fired immediately before a merge occurs. Is parameterized by targetBranchName and releaseBranchName |
 | postDevelopMergeCallback | Function | Callback fired after a successful merge with development occurs. |
 | postMasterMergeCallback | Function | Callback fired after a successful merge with master occurs. |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodegit-flow",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "nodegit-flow contains gitflow methods that aren't include in the vanilla nodegit package",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/Hotfix.js
+++ b/src/Hotfix.js
@@ -67,6 +67,7 @@ class Hotfix {
       keepBranch,
       message,
       processMergeMessageCallback,
+      beforeMergeCallback = () => {},
       postDevelopMergeCallback = () => {},
       postMasterMergeCallback = () => {}
     } = options;
@@ -122,7 +123,8 @@ class Hotfix {
 
         // Merge hotfix into develop
         if (!cancelDevelopMerge) {
-          return utils.Repo.merge(developBranch, hotfixBranch, repo, processMergeMessageCallback)
+          return Promise.resolve(beforeMergeCallback(developBranch, hotfixBranch))
+            .then(() => utils.Repo.merge(developBranch, hotfixBranch, repo, processMergeMessageCallback))
             .then(utils.InjectIntermediateCallback(postDevelopMergeCallback));
         }
         return Promise.resolve();
@@ -133,7 +135,8 @@ class Hotfix {
         const tagName = versionPrefix + hotfixVersion;
         // Merge the hotfix branch into master
         if (!cancelMasterMerge) {
-          return utils.Repo.merge(masterBranch, hotfixBranch, repo, processMergeMessageCallback)
+          return Promise.resolve(beforeMergeCallback(masterBranch, hotfixBranch))
+            .then(() => utils.Repo.merge(masterBranch, hotfixBranch, repo, processMergeMessageCallback))
             .then(utils.InjectIntermediateCallback(postMasterMergeCallback))
             .then((oid) => utils.Tag.create(oid, tagName, message, repo));
         }

--- a/src/Release.js
+++ b/src/Release.js
@@ -74,6 +74,7 @@ class Release {
       keepBranch,
       message,
       processMergeMessageCallback,
+      beforeMergeCallback = () => {},
       postDevelopMergeCallback = () => {},
       postMasterMergeCallback = () => {}
     } = options;
@@ -129,7 +130,8 @@ class Release {
 
         // Merge release into develop
         if (!cancelDevelopMerge) {
-          return utils.Repo.merge(developBranch, releaseBranch, repo, processMergeMessageCallback)
+          return Promise.resolve(beforeMergeCallback(developBranch, releaseBranch))
+            .then(() => utils.Repo.merge(developBranch, releaseBranch, repo, processMergeMessageCallback))
             .then(utils.InjectIntermediateCallback(postDevelopMergeCallback));
         }
         return Promise.resolve();
@@ -140,7 +142,8 @@ class Release {
         const tagName = versionPrefix + releaseVersion;
         // Merge the release branch into master
         if (!cancelMasterMerge) {
-          return utils.Repo.merge(masterBranch, releaseBranch, repo, processMergeMessageCallback)
+          return Promise.resolve(beforeMergeCallback(masterBranch, releaseBranch))
+            .then(() => utils.Repo.merge(masterBranch, releaseBranch, repo, processMergeMessageCallback))
             .then(utils.InjectIntermediateCallback(postMasterMergeCallback))
             .then((oid) => utils.Tag.create(oid, tagName, message, repo));
         }


### PR DESCRIPTION
Used to inform caller that a merge will be taking place since a merge may or may not occur in hotfix/release