### PR TITLE
We should have beforeMergeCallback for feature too

### DIFF
--- a/src/Feature.js
+++ b/src/Feature.js
@@ -74,6 +74,7 @@ class Feature {
       keepBranch,
       isRebase,
       preRebaseCallback = () => {},
+      beforeMergeCallback = () => {},
       processMergeMessageCallback,
       postMergeCallback = () => {},
       beforeRebaseFinishCallback = () => {}
@@ -121,7 +122,8 @@ class Feature {
         cancelDevelopMerge = isSameCommit || isRebase;
 
         if (!cancelDevelopMerge) {
-          return utils.Repo.merge(developBranch, featureBranch, repo, processMergeMessageCallback)
+          return Promise.resolve(beforeMergeCallback(developBranch, featureBranch))
+            .then(() => utils.Repo.merge(developBranch, featureBranch, repo, processMergeMessageCallback))
             .then(utils.InjectIntermediateCallback(postMergeCallback));
         } else if (isRebase && !isSameCommit) {
           return Promise.resolve(preRebaseCallback(developBranchName, featureBranchName))

--- a/src/Feature.js
+++ b/src/Feature.js
@@ -122,7 +122,7 @@ class Feature {
         cancelDevelopMerge = isSameCommit || isRebase;
 
         if (!cancelDevelopMerge) {
-          return Promise.resolve(beforeMergeCallback(developBranch, featureBranch))
+          return Promise.resolve(beforeMergeCallback(developBranchName, featureBranchName))
             .then(() => utils.Repo.merge(developBranch, featureBranch, repo, processMergeMessageCallback))
             .then(utils.InjectIntermediateCallback(postMergeCallback));
         } else if (isRebase && !isSameCommit) {

--- a/src/Hotfix.js
+++ b/src/Hotfix.js
@@ -80,6 +80,9 @@ class Hotfix {
       return Promise.reject(new Error('Hotfix name is required'));
     }
 
+    let developBranchName;
+    let hotfixBranchName;
+    let masterBranchName;
     let cancelMasterMerge;
     let cancelDevelopMerge;
     let developBranch;
@@ -92,9 +95,9 @@ class Hotfix {
     let versionPrefix;
     return Config.getConfig(repo)
       .then((config) => {
-        const developBranchName = config['gitflow.branch.develop'];
-        const hotfixBranchName = config['gitflow.prefix.hotfix'] + hotfixVersion;
-        const masterBranchName = config['gitflow.branch.master'];
+        developBranchName = config['gitflow.branch.develop'];
+        hotfixBranchName = config['gitflow.prefix.hotfix'] + hotfixVersion;
+        masterBranchName = config['gitflow.branch.master'];
         versionPrefix = config['gitflow.prefix.versiontag'];
 
         // Get the develop, master, and hotfix branch
@@ -123,7 +126,7 @@ class Hotfix {
 
         // Merge hotfix into develop
         if (!cancelDevelopMerge) {
-          return Promise.resolve(beforeMergeCallback(developBranch, hotfixBranch))
+          return Promise.resolve(beforeMergeCallback(developBranchName, hotfixBranchName))
             .then(() => utils.Repo.merge(developBranch, hotfixBranch, repo, processMergeMessageCallback))
             .then(utils.InjectIntermediateCallback(postDevelopMergeCallback));
         }
@@ -135,7 +138,7 @@ class Hotfix {
         const tagName = versionPrefix + hotfixVersion;
         // Merge the hotfix branch into master
         if (!cancelMasterMerge) {
-          return Promise.resolve(beforeMergeCallback(masterBranch, hotfixBranch))
+          return Promise.resolve(beforeMergeCallback(masterBranchName, hotfixBranchName))
             .then(() => utils.Repo.merge(masterBranch, hotfixBranch, repo, processMergeMessageCallback))
             .then(utils.InjectIntermediateCallback(postMasterMergeCallback))
             .then((oid) => utils.Tag.create(oid, tagName, message, repo));

--- a/src/Release.js
+++ b/src/Release.js
@@ -87,6 +87,9 @@ class Release {
       return Promise.reject(new Error('Release name is required'));
     }
 
+    let developBranchName;
+    let releaseBranchName;
+    let masterBranchName;
     let developBranch;
     let releaseBranch;
     let masterBranch;
@@ -99,9 +102,9 @@ class Release {
     let versionPrefix;
     return Config.getConfig(repo)
       .then((config) => {
-        const developBranchName = config['gitflow.branch.develop'];
-        const releaseBranchName = config['gitflow.prefix.release'] + releaseVersion;
-        const masterBranchName = config['gitflow.branch.master'];
+        developBranchName = config['gitflow.branch.develop'];
+        releaseBranchName = config['gitflow.prefix.release'] + releaseVersion;
+        masterBranchName = config['gitflow.branch.master'];
         versionPrefix = config['gitflow.prefix.versiontag'];
 
         // Get the develop, master, and release branch
@@ -130,7 +133,7 @@ class Release {
 
         // Merge release into develop
         if (!cancelDevelopMerge) {
-          return Promise.resolve(beforeMergeCallback(developBranch, releaseBranch))
+          return Promise.resolve(beforeMergeCallback(developBranchName, releaseBranchName))
             .then(() => utils.Repo.merge(developBranch, releaseBranch, repo, processMergeMessageCallback))
             .then(utils.InjectIntermediateCallback(postDevelopMergeCallback));
         }
@@ -142,7 +145,7 @@ class Release {
         const tagName = versionPrefix + releaseVersion;
         // Merge the release branch into master
         if (!cancelMasterMerge) {
-          return Promise.resolve(beforeMergeCallback(masterBranch, releaseBranch))
+          return Promise.resolve(beforeMergeCallback(masterBranchName, releaseBranchName))
             .then(() => utils.Repo.merge(masterBranch, releaseBranch, repo, processMergeMessageCallback))
             .then(utils.InjectIntermediateCallback(postMasterMergeCallback))
             .then((oid) => utils.Tag.create(oid, tagName, message, repo));


### PR DESCRIPTION
This is consistent with the other finish methods. It is necessary to inform the caller of what operations nodegit-flow intends to make on the repository.