### PR TITLE
Use snapshots and locks for all config reads/writes

### DIFF
--- a/spec/tests/Base-spec.js
+++ b/spec/tests/Base-spec.js
@@ -7,12 +7,26 @@ const { Base } = NodeGit.Flow.__TEST__;
 describe('Base', function() {
   beforeEach(function() {
     const repoConfig = {
-      getString(key) {
-        const defaultConfig = NodeGit.Flow.getConfigDefault();
-        return defaultConfig[key] || true;
+      lock() {
+        return Promise.resolve({
+          commit() {
+            return Promise.resolve();
+          }
+        });
+      },
+      getString() {
+        throw new Error('Do not call config.getString without taking a snapshot first.');
       },
       setString() {
         return Promise.resolve();
+      },
+      snapshot() {
+        return Promise.resolve({
+          getString(key) {
+            const defaultConfig = NodeGit.Flow.getConfigDefault();
+            return defaultConfig[key] || true;
+          }
+        });
       }
     };
     this.repo = {

--- a/src/Config.js
+++ b/src/Config.js
@@ -13,7 +13,8 @@ module.exports = (NodeGit, { constants }) => {
     }
 
     return repo.config()
-      .then((config) => config.getString(configKey))
+      .then((config) => config.snapshot())
+      .then((snapshot) => snapshot.getString(configKey))
       .catch(() => Promise.reject(new Error(`Failed to read config value ${configKey}`)));
   }
 
@@ -89,9 +90,10 @@ module.exports = (NodeGit, { constants }) => {
       const configKeys = _getConfigKeys();
 
       return repo.config()
-        .then((config) => {
+        .then((config) => config.snapshot())
+        .then((snapshot) => {
           const promises = configKeys.map((key) => {
-            return config.getString(key);
+            return snapshot.getString(key);
           });
 
           return Promise.all(promises);


### PR DESCRIPTION
The tests were failing for reasons that made no sense and went away when I isolated them. After about 10 runs I finally got a run where the tests passed.

The point is that if the tests fail I don't think it's my fault.

I linked this into GitKraken and it solved the git flow refreshing issue.