### PR TITLE
Adds option to skip develop merge

### DIFF
--- a/src/Hotfix.js
+++ b/src/Hotfix.js
@@ -77,7 +77,8 @@ module.exports = (NodeGit, { constants, utils }, { Config }) => {
         postDevelopMergeCallback = () => {},
         postMasterMergeCallback = () => {},
         postCheckoutHook = () => {},
-        signingCallback
+        signingCallback,
+        onlyMaster = false,
       } = options;
 
       if (!repo) {
@@ -129,7 +130,7 @@ module.exports = (NodeGit, { constants, utils }, { Config }) => {
 
           // If either develop or master point to the same commit as the hotfix branch cancel
           // their respective merge
-          cancelDevelopMerge = developCommit.id().toString() === hotfixCommit.id().toString();
+          cancelDevelopMerge = onlyMaster || developCommit.id().toString() === hotfixCommit.id().toString();
           cancelMasterMerge = masterCommit.id().toString() === hotfixCommit.id().toString();
 
           // Merge hotfix into develop

--- a/src/Release.js
+++ b/src/Release.js
@@ -84,7 +84,8 @@ module.exports = (NodeGit, { constants, utils }, { Config }) => {
         postDevelopMergeCallback = () => {},
         postMasterMergeCallback = () => {},
         postCheckoutHook = () => {},
-        signingCallback
+        signingCallback,
+        onlyMaster = false,
       } = options;
 
       if (!repo) {
@@ -136,7 +137,7 @@ module.exports = (NodeGit, { constants, utils }, { Config }) => {
 
           // If either develop or master point to the same commit as the release branch cancel
           // their respective merge
-          cancelDevelopMerge = developCommit.id().toString() === releaseCommit.id().toString();
+          cancelDevelopMerge = onlyMaster || developCommit.id().toString() === releaseCommit.id().toString();
           cancelMasterMerge = masterCommit.id().toString() === releaseCommit.id().toString();
 
           // Merge release into develop


### PR DESCRIPTION
Introduces an `onlyMaster` option to hotfix and release flows.

This allows skipping the merge into the develop branch, providing more
flexibility in scenarios where changes should only be applied to master, like after the user resolves a conflict while merging into the develop branch and the finish git flow continues but it only needs to be applied to master.

NOTE: to test it, yarn link with GKD having checked out the PR https://github.com/gitkraken/gitkraken-client/pull/10493
